### PR TITLE
🔖 Auto-update Helm chart to v0.1.9

### DIFF
--- a/oci_lens_terraform/modules/app/main.tf
+++ b/oci_lens_terraform/modules/app/main.tf
@@ -23,7 +23,7 @@ resource "oci_identity_policy" "workload_identity_policy" {
 resource "helm_release" "app" {
   name      = "lens"
   namespace = kubernetes_namespace.ns.metadata[0].name
-  chart = "https://iduyx1qnmway.objectstorage.us-ashburn-1.oci.customer-oci.com/p/sYtP3M92P48fg9xb8P5IFja_V7yjYvrTlPrjDZxKgns4vDoNTRqLt7uN_vnqqfhd/n/iduyx1qnmway/b/helm-charts/o/lens-0.1.9-da86b16.tgz"
+  chart = "https://iduyx1qnmway.objectstorage.us-ashburn-1.oci.customer-oci.com/p/Pag4Pa8XTf66VL2Sb-Efob5xvlNm_d2_FF6ZxDdHCWEfDDjByJasC1yttGZjAeS5/n/iduyx1qnmway/b/helm-charts/o/lens-0.1.9-108c3ec.tgz"
   wait            = true
   timeout         = 1800
   atomic          = false


### PR DESCRIPTION
This PR updates the Helm chart URL in `oci_lens_terraform/modules/app/main.tf`.

- New Helm chart: https://iduyx1qnmway.objectstorage.us-ashburn-1.oci.customer-oci.com/p/Pag4Pa8XTf66VL2Sb-Efob5xvlNm_d2_FF6ZxDdHCWEfDDjByJasC1yttGZjAeS5/n/iduyx1qnmway/b/helm-charts/o/lens-0.1.9-108c3ec.tgz