### PR TITLE
Fix(pod-node-mapper): correct liveness/readiness probes to check main process

### DIFF
--- a/oci-scanner-plugin-helm/templates/pod-node-mapper.yaml
+++ b/oci-scanner-plugin-helm/templates/pod-node-mapper.yaml
@@ -60,10 +60,7 @@ spec:
         
         livenessProbe:
           exec:
-            command:
-            - pgrep
-            - -f
-            - python3
+            command: ["sh", "-c", "kill -0 1"]
           initialDelaySeconds: 30
           periodSeconds: 30
           timeoutSeconds: 5
@@ -71,10 +68,7 @@ spec:
         
         readinessProbe:
           exec:
-            command:
-            - pgrep
-            - -f
-            - python3
+            command: ["sh", "-c", "kill -0 1"]
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5


### PR DESCRIPTION
Replace `pgrep -f python3` with a PID 1 exec check to prevent false probe failures during sleep cycles; avoids unnecessary container restarts.